### PR TITLE
(+) fix : deprecated ingress api version

### DIFF
--- a/examples/service-nginx-ingress.yaml
+++ b/examples/service-nginx-ingress.yaml
@@ -33,8 +33,9 @@ spec:
       targetPort: 80
 
 ---
-
-apiVersion: networking.k8s.io/v1beta1
+# deprecated :
+# apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: nginx-ingress
@@ -46,6 +47,9 @@ spec:
       http:
         paths:
           - path: /
+            pathType: Prefix
             backend:
-              serviceName: nginx-service
-              servicePort: 80
+              service:
+                name: nginx-service
+                port:
+                  number: 80

--- a/templates/service-with-ingress.yaml
+++ b/templates/service-with-ingress.yaml
@@ -1,4 +1,6 @@
-apiVersion: networking.k8s.io/v1beta1
+# deprecated :
+# apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: ingress-name
@@ -10,6 +12,9 @@ spec:
       http:
         paths:
           - path: /
+            pathType: Prefix
             backend:
-              serviceName: service-name
-              servicePort: 80
+              service:
+                name: nginx-service
+                port:
+                  number: 80


### PR DESCRIPTION
fix error: 
resource mapping not found for name: "ingress-name" namespace: "" from "templates/service-with-ingress.yaml": no matches for kind "Ingress" in version "networking.k8s.io/v1beta1"

solution : 
update api version into : "networking.k8s.io/v1"